### PR TITLE
feat(ui): show Vuetify popup instead of alert when backend API is not running

### DIFF
--- a/src/views/CalibrationCard.vue
+++ b/src/views/CalibrationCard.vue
@@ -29,8 +29,34 @@
         </v-col>
       </v-row>
     </v-container>
+
+    <v-dialog v-model="errorDialog" max-width="400" persistent>
+      <v-card>
+        <v-card-title class="text-h6">
+          <v-icon left color="error">mdi-alert-circle</v-icon>
+          Error
+        </v-card-title>
+        <v-card-text class="pt-4">{{ errorMessage }}</v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="primary" text @click="errorDialog = false">OK</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </div>
 </template>
+
+<style>
+.v-dialog__content {
+  align-items: center !important;
+  justify-content: center !important;
+  width: 100vw !important;
+}
+
+.v-dialog {
+  margin: 0 !important;
+}
+</style>
 
 <script>
 import Toolbar from "@/components/general/Toolbar.vue";
@@ -40,6 +66,12 @@ export default {
   components: {
     Toolbar,
   },
+  data() {
+    return {
+      errorDialog: false,
+      errorMessage: "",
+    };
+  },
   methods: {
     async goToCameraConfig() {
       try {
@@ -48,14 +80,14 @@ export default {
         if (res.status === 200 && res.data.status === "ok") {
           this.$router.push("/calibration/configuration");
         } else {
-          alert("API is not ready. Please try again later.");
+          this.errorMessage = "API is not ready. Please try again later.";
+          this.errorDialog = true;
         }
       } catch (err) {
-        alert("Cannot reach backend. Is the API running?");
+        this.errorMessage = "Cannot reach backend. Is the API running?";
+        this.errorDialog = true;
       }
     },
- 
   },
 };
 </script>
-


### PR DESCRIPTION
### Summary
Improved user experience when backend API is offline by replacing the default browser alert with a Vuetify dialog.

### Before
<img width="1919" height="1088" alt="Screenshot 2025-11-13 123354" src="https://github.com/user-attachments/assets/d868ca17-8b4d-4a70-95ba-461100e34bcb" />


### After
<img width="1459" height="803" alt="Screenshot 2025-11-13 151810" src="https://github.com/user-attachments/assets/f41a5259-2a6a-4e6a-8730-4a91f28af3bf" />


### Changes
- Added `<v-dialog>` popup for API connectivity errors.
- Removed old `alert()` calls.
- Maintains existing layout and logic (no structural changes).

### Why
Addresses [eye-tracker-api#28](https://github.com/ruxailab/eye-tracker-api/issues/28)  
and improves UX by using a consistent, non-blocking Vuetify component instead of the native alert.
