### PR TITLE
fix: add missing firebase firestore import to prevent crash

### DIFF
--- a/src/store/calibration.js
+++ b/src/store/calibration.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import firebase from 'firebase/app';
+import 'firebase/firestore';
 import router from '@/router';
 export default {
     state: {


### PR DESCRIPTION
 Bug Fix

What is the bug?
The application crashes immediately after clicking "Get Started" (loading the dashboard) with the error:
"TypeError: firebase.firestore is not a function".

Why does it happen?
The `CalibTable` component attempts to fetch previous calibrations on creation (`created` hook). However, `src/store/calibration.js` imports only `firebase/app` without importing the Firestore module. This causes the `store.getAllCalibs` function to fail when accessing `firebase.firestore()`.

The Solution
Added `import 'firebase/firestore';` to `src/store/calibration.js`.

How to Test
1. Run the app locally.
2. Click "Get Started" to enter the dashboard.
3. Observe that the "not a function" crash is gone and the page loads (requests will now correctly attempt to reach Firestore).