### PR TITLE
Fix: Prevent Crash When Face Leaves Camera View During Calibration

### DIFF
--- a/src/views/CameraConfiguration.vue
+++ b/src/views/CameraConfiguration.vue
@@ -224,7 +224,20 @@ export default {
 
             const th = this
 
+            // 🛡️ DEFENSIVE GUARD: Only process if face is detected
+            // This prevents crash when user moves face out of camera view
+            if (!this.predictions || this.predictions.length === 0) {
+                // Face not detected - continue camera loop but skip rendering
+                return;
+            }
+
             this.predictions.forEach((pred) => {
+                // Additional safety check for required annotations
+                if (!pred || !pred.annotations) {
+                    console.warn('Incomplete face data, skipping frame');
+                    return;
+                }
+                
                 // left eye
                 const leftIris = pred.annotations.leftEyeIris;
                 const leftEyelid = pred.annotations.leftEyeUpper0.concat(pred.annotations.leftEyeLower0);


### PR DESCRIPTION
### Problem

The app crashes when a user’s face moves out of the camera view during calibration, causing the Vue router to crash and requiring a full reload. Calibration data is lost.

**Error:** `Cannot read property 'annotations' of undefined`

---

### Root Cause

The TensorFlow.js face detection model returns an empty array when no face is detected. The code accessed `prediction[0].annotations` without checking for an empty array, causing an uncaught exception that crashed the app and router.

---

### Solution

Added defensive guards in two places:

* **DoubleCalibrationRecord.vue**

  * Guard against empty predictions
  * Validate face landmarks
  * Pause/resume calibration with 500ms retry
  * Add `faceDetected` state and warning banner

* **CameraConfiguration.vue**

  * Add null checks
  * Skip preview rendering when no face is detected

---

### Changes & Impact

* Prevents crashes on missing face detection
* Shows warning banner when face is out of frame
* Automatically pauses and resumes calibration
* No data loss during temporary face absence
