### PR TITLE
fix: force fullscreen during calibration

### DIFF
--- a/src/views/DoubleCalibrationRecord.vue
+++ b/src/views/DoubleCalibrationRecord.vue
@@ -1,5 +1,42 @@
 <template>
   <div style="height: 100%;">
+    <!-- Fullscreen required during calibration -->
+    <v-dialog v-model="fullscreenRequiredDialog" max-width="520" persistent>
+      <v-card>
+        <v-card-title class="d-flex align-center">
+          <v-icon left>mdi-fullscreen</v-icon>
+          Go fullscreen
+        </v-card-title>
+        <v-card-text>
+          Please keep fullscreen on during calibration so the app can measure screen borders correctly.
+        </v-card-text>
+        <v-card-actions class="justify-end">
+          <v-btn color="#FF425A" dark @click="requestFullscreenAndClose">
+            Enter fullscreen
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <!-- Block navigation during active calibration -->
+    <v-dialog v-model="navigationBlockedDialog" max-width="520">
+      <v-card>
+        <v-card-title class="d-flex align-center">
+          <v-icon left>mdi-lock</v-icon>
+          Calibration in progress
+        </v-card-title>
+        <v-card-text>
+          Navigation is disabled during calibration to ensure accurate border
+          positioning. Please finish calibration first.
+        </v-card-text>
+        <v-card-actions class="justify-end">
+          <v-btn color="#FF425A" dark @click="navigationBlockedDialog = false">
+            OK
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
     <div v-if="!model" class="center-container">
       <v-progress-circular :size="80" :width="8" indeterminate color="black" class="loading-spinner"
         style="margin-bottom: 16px;"></v-progress-circular>
@@ -242,7 +279,10 @@ export default {
       stepperStep: 1,
       showStepper: true,
       calibrationStarted: false,
-      loadingConfig: false
+      loadingConfig: false,
+
+      fullscreenRequiredDialog: false,
+      navigationBlockedDialog: false,
     };
   },
   computed: {
@@ -311,7 +351,91 @@ export default {
     console.log("UsedPattern inteiro", this.usedPattern);
 
   },
+  mounted() {
+    document.addEventListener("fullscreenchange", this.onFullscreenChange);
+    document.addEventListener("webkitfullscreenchange", this.onFullscreenChange);
+    window.addEventListener("beforeunload", this.onBeforeUnload);
+
+    this.applyCalibrationScrollLock();
+
+    if (!this.isFullscreen()) {
+      this.fullscreenRequiredDialog = true;
+    }
+  },
+  beforeDestroy() {
+    document.removeEventListener("fullscreenchange", this.onFullscreenChange);
+    document.removeEventListener("webkitfullscreenchange", this.onFullscreenChange);
+    window.removeEventListener("beforeunload", this.onBeforeUnload);
+
+    this.removeCalibrationScrollLock();
+  },
+  beforeRouteLeave(to, from, next) {
+    if (this.calibrationStarted && !this.calibFinished) {
+      this.navigationBlockedDialog = true;
+      next(false);
+      return;
+    }
+    next();
+  },
   methods: {
+    applyCalibrationScrollLock() {
+      const body = document.body;
+      const html = document.documentElement;
+      if (!body || !html) return;
+
+      body.style.overflow = "hidden";
+      html.style.overflow = "hidden";
+      body.style.overscrollBehavior = "none";
+      html.style.overscrollBehavior = "none";
+    },
+    removeCalibrationScrollLock() {
+      const body = document.body;
+      const html = document.documentElement;
+      if (!body || !html) return;
+
+      body.style.overflow = "";
+      html.style.overflow = "";
+      body.style.overscrollBehavior = "";
+      html.style.overscrollBehavior = "";
+    },
+    isFullscreen() {
+      return !!(
+        document.fullscreenElement ||
+        document.webkitFullscreenElement ||
+        document.mozFullScreenElement ||
+        document.msFullscreenElement
+      );
+    },
+    requestFullscreen(element) {
+      const el = element || document.documentElement;
+      if (el.requestFullscreen) return el.requestFullscreen();
+      if (el.mozRequestFullScreen) return el.mozRequestFullScreen();
+      if (el.webkitRequestFullscreen) return el.webkitRequestFullscreen();
+      if (el.msRequestFullscreen) return el.msRequestFullscreen();
+      return Promise.reject(new Error("Fullscreen API not supported"));
+    },
+    async requestFullscreenAndClose() {
+      try {
+        await this.requestFullscreen(document.documentElement);
+      } catch (e) {
+        // Keep dialog open; browser will show its own UI hints if blocked.
+      }
+      if (this.isFullscreen()) {
+        this.fullscreenRequiredDialog = false;
+      }
+    },
+    onFullscreenChange() {
+      if (this.calibrationStarted && !this.calibFinished && !this.isFullscreen()) {
+        this.fullscreenRequiredDialog = true;
+        this.showStepper = true;
+      }
+    },
+    onBeforeUnload(e) {
+      if (this.calibrationStarted && !this.calibFinished) {
+        e.preventDefault();
+        e.returnValue = "";
+      }
+    },
     generateCalibrationPattern(pointCount, width, height, offset) {
       const patterns = [];
       
@@ -415,10 +539,18 @@ export default {
     },
     
     startTraining() {
+      if (!this.isFullscreen()) {
+        this.fullscreenRequiredDialog = true;
+        return;
+      }
       this.showStepper = false;
       this.calibrationStarted = true;
     },
     startValidation() {
+      if (!this.isFullscreen()) {
+        this.fullscreenRequiredDialog = true;
+        return;
+      }
       this.showStepper = false;
       this.calibrationStarted = true;
     },
@@ -432,10 +564,26 @@ export default {
         }
 
         if ((event.key === "s" || event.key === "S" || event.key === "Enter")) {
+          if (!th.isFullscreen()) {
+            th.fullscreenRequiredDialog = true;
+            th.showStepper = true;
+            return;
+          }
           if (i < pattern.length) {
             document.removeEventListener('keydown', keydownHandler)
             th.isCollecting = true
-            await th.extract(pattern[i], timeBetweenCaptures)
+            try {
+              await th.extract(pattern[i], timeBetweenCaptures)
+            } catch (e) {
+              th.isCollecting = false
+              if (e && e.message === "fullscreen_required") {
+                th.fullscreenRequiredDialog = true
+                th.showStepper = true
+                document.addEventListener('keydown', keydownHandler)
+                return
+              }
+              throw e
+            }
             th.isCollecting = false
 
             th.$store.commit('setIndex', i)
@@ -482,6 +630,9 @@ export default {
     async extract(point, timeBetweenCaptures) {
       point.data = [];
       for (var a = 0; a < this.predByPointCount;) {
+        if (!this.isFullscreen()) {
+          throw new Error("fullscreen_required");
+        }
         const prediction = await this.detectFace();
 
         // 🛡️ DEFENSIVE GUARD: Check if face is detected
@@ -789,13 +940,6 @@ export default {
 </script>
 
 <style scoped>
-body,
-html {
-  margin: 0;
-  padding: 0;
-  overflow: hidden;
-}
-
 #canvas {
   position: fixed;
   top: 0;


### PR DESCRIPTION
Fixes (#100)
Block navigation/scroll during calibration so border-relative points stay correct.

What i did-
Enforce fullscreen before starting calibration and keep it required during calibration.
Block navigation and scrolling while calibration is active.
If fullscreen is exited mid-calibration, pause and require fullscreen again.

Why?
Calibration uses border-relative coordinates; any resize/scroll/navigation breaks the assumption and makes border measurements inaccurate.