### PR TITLE
Increase the min calibration points to 7 instead of 2 to avoid overfitting

### DIFF
--- a/src/components/calibration/GeneralConfigCard.vue
+++ b/src/components/calibration/GeneralConfigCard.vue
@@ -11,11 +11,11 @@
                     <p class="help-text">Give your calibration a unique identifier</p>
                 </div>
                 <div class="custom-outline">
-                    <Slider :value="pointNumber" :min="Number(2)" :max="Number(9)" label="Calibration Points"
+                    <Slider :value="pointNumber" :min="Number(7)" :max="Number(9)" label="Calibration Points"
                         @input="updatePointNumber" />
-                    <p class="help-text">Number of points to calibrate (4-9 points recommended)</p>
+                    <p class="help-text">Number of points to calibrate (7-9 points recommended)</p>
                     
-                    <Slider :value="samplePerPoint" :min="Number(90)" :max="Number(90)" label="Samples Per Point" @input="updateSamplePerPoint" />
+                    <Slider :value="samplePerPoint" :min="Number(100)" :max="Number(150)" label="Samples Per Point" @input="updateSamplePerPoint" />
                     <p class="help-text">More samples = better accuracy but longer calibration</p>
                     
                     <Slider :value="msPerCapture" :min="Number(100)" :step="5" :max="Number(100)"


### PR DESCRIPTION
## Description
This PR introduces a minimum threshold for calibration points to ensure that the gaze prediction models are trained on a sufficient number of samples.

Previously, calibration could proceed with too few points, leading to unstable models and unreliable evaluation results.

## Problem
- Calibration with very few points can result in overfitting and noisy predictions.

- Model performance becomes highly sensitive to outliers when the sample size is too small.

- Evaluation metrics are not meaningful with insufficient calibration data.

## What Changed
- Enforced a minimum of 7 calibration points before training is allowed.

- Improved overall robustness and consistency of gaze prediction results by increasing the number of samples per point to 100.

## Rule of Thumb
As a general rule of thumb in regression-based calibration tasks:

A minimum of 5–10 well-distributed calibration points is required to obtain a stable mapping.

Setting the minimum to 7 points provides a reasonable balance between usability and statistical reliability.

This ensures:

Better generalization

More stable model coefficients

More meaningful evaluation metrics

