### PR TITLE
feat(calibration): add Fullscreen mode during calibration

### DIFF
--- a/src/views/DoubleCalibrationRecord.vue
+++ b/src/views/DoubleCalibrationRecord.vue
@@ -370,6 +370,7 @@ export default {
 
     if (!this.isFullscreen()) {
       this.fullscreenRequiredDialog = true;
+      this.attemptAutoFullscreen();
     }
   },
   beforeDestroy() {
@@ -433,6 +434,15 @@ export default {
       if (this.isFullscreen()) {
         this.fullscreenRequiredDialog = false;
       }
+    },
+    attemptAutoFullscreen() {
+      this.requestFullscreen(document.documentElement)
+        .then(() => {
+          if (this.isFullscreen()) {
+            this.fullscreenRequiredDialog = false;
+          }
+        })
+        .catch(() => {});
     },
     onFullscreenChange() {
       if (this.calibrationStarted && !this.calibFinished && !this.isFullscreen()) {


### PR DESCRIPTION
## What this fixes
Limits user interaction and navigation to fullscreen during calibration so the app can capture the relative position of every screen border accurately.

Fixes #100

## What I changed
- **src/views/DoubleCalibrationRecord.vue**: When the calibration record view mounts and the user is not already in fullscreen, the existing "Go fullscreen" dialog is shown and the new `attemptAutoFullscreen()` method is called. It requests fullscreen once; if the browser grants it, the dialog is closed and calibration runs in fullscreen without an extra click. If the request fails (e.g. no user gesture), the dialog remains and the user can still click "Enter fullscreen". No other flows or UI were changed.

## How I tested it
- Went through calibration setup and camera, then "Start Calibration" to reach the record view.
- With a browser that allows programmatic fullscreen after navigation, fullscreen was requested automatically and the dialog closed when fullscreen was entered.
- With a browser that blocked the automatic request, the "Go fullscreen" dialog stayed and "Enter fullscreen" still worked.
- Confirmed existing behavior: fullscreen is still required before/during training and validation, and exiting fullscreen during calibration still re-opens the dialog and stepper.

## Notes
Automatic request is best-effort; when it is blocked, the existing dialog remains the fallback. No new dependencies or config were added.