### PR TITLE
fix: sliders not working (fixes #54)

### DIFF
--- a/src/components/general/Slider.vue
+++ b/src/components/general/Slider.vue
@@ -32,21 +32,31 @@ export default {
         label: String,
     },
     data() {
+        const num = Number(this.value);
         return {
-            sliderValue: this.value,
+            sliderValue: (num === num ? num : this.min),
         };
     },
     watch: {
         value(newVal) {
-            this.sliderValue = newVal;
+            const num = Number(newVal);
+            if (num === num && num !== this.sliderValue) {
+                this.sliderValue = num;
+            }
         },
         sliderValue(newVal) {
-            this.$emit('input', newVal);
+            const num = Number(newVal);
+            const safe = num === num ? num : this.min;
+            if (this.sliderValue !== safe) {
+                this.sliderValue = safe;
+            }
+            this.$emit('input', safe);
         },
     },
     methods: {
         updateValue() {
-            this.$emit('input', this.sliderValue);
+            const num = Number(this.sliderValue);
+            this.$emit('input', num === num ? num : this.min);
         },
     },
 };


### PR DESCRIPTION
- Fixes #54 .
## Summary
Fixes sliders not working by ensuring the `Slider` component always uses and emits numbers. Vuetify’s `v-slider` and the Vuex store were sometimes getting string values, which broke binding and made sliders unresponsive or out of sync.

## Problem
The wrapper around `v-slider` passed the `value` prop and emitted `input` without normalizing types. When the slider or store produced or stored strings (e.g. `"7"` instead of `7`), the component’s internal state and the store could diverge. That led to sliders that didn’t move, didn’t reflect the store, or didn’t update the UI correctly.

## Solution
Treat the value as a number everywhere: coerce the prop to a number when initializing and when it changes, keep the internal `sliderValue` as a number (including when `v-slider` sends a string), and always emit a number to the parent so the store stays numeric.

## Changes Made
- **`src/components/general/Slider.vue`**
  - **data()**: Initialize `sliderValue` with `Number(this.value)`, falling back to `min` when the result is NaN.
  - **value watcher**: Coerce the new value to a number and only assign to `sliderValue` when it’s different, to avoid unnecessary updates and keep state in sync with the prop.
  - **sliderValue watcher**: Coerce the new value to a number, assign it back to `sliderValue` so it stays numeric, and emit that number so the store and parent always receive a number.
  - **updateValue()**: Emit a number (with the same NaN → `min` fallback) instead of the raw `sliderValue`.

NaN is detected with `num === num` to keep the change minimal and avoid extra helpers.

## Testing
- `npm run serve` → opened Calibration → Configuration.
- Dragged Calibration Points, Samples Per Point, Milliseconds Per Capture, Distance Threshold, Radius, and Offset sliders; values updated and stayed in sync.
- Opened the recalibrate modal and moved Points Distance Threshold; it updated correctly.
- Opened Camera Configuration and moved left/right eye threshold sliders; both responded and showed the right values.