### PR TITLE
 Fix: Wire up missing Vuex mutation setCalibrationPattern and calibValidationResult state

### DIFF
--- a/src/store/calibration.js
+++ b/src/store/calibration.js
@@ -135,6 +135,9 @@ export default {
       state.runtime.usedPattern = [];
       state.runtime.finished = false;
     },
+    setCalibrationPattern(state, adapted) {
+      state.runtime.usedPattern = adapted;
+    },
     resetAll(state) {
       state.calibName = "";
       state.pointNumber = 9;

--- a/src/store/predict.js
+++ b/src/store/predict.js
@@ -3,7 +3,8 @@ export default {
         fixedTrainData: null,
         predictTrainData: null,
         prediction: null,
-        model: null
+        model: null,
+        calibValidationResult: null
     },
     mutations: {
         saveFixed(state, fixedTrainData) {
@@ -17,6 +18,9 @@ export default {
         },
         predictNow(state) {
             console.log(state)
+        },
+        setCalibValidationResult(state, result) {
+            state.calibValidationResult = result
         }
     },
     actions: {

--- a/src/views/DoubleCalibrationRecord.vue
+++ b/src/views/DoubleCalibrationRecord.vue
@@ -791,6 +791,8 @@ export default {
           console.error('Error parsing predictions string:', error);
         }
       }
+      this.$store.commit('setCalibValidationResult', predictions)
+
       for (var a = 0; a < this.usedPattern.length; a++) {
         const element = predictions[this.usedPattern[a].x.toString().split('.')[0]][this.usedPattern[a].y.toString().split('.')[0]]
 


### PR DESCRIPTION
## Problem

`PostCalibration.vue`'s `applyCalibResult()` method was silently broken across two missing links:

1. It read `calibValidationResult` from the predict store — a property that never existed in state
2. It committed `setCalibrationPattern` — a mutation that was never defined in `calibration.js`

The method always exited at the null-guard, meaning the adapted calibration pattern (with prediction coordinates, precision, and accuracy) was **never reactively stored**. Post-calibration visualizations only worked because `DoubleCalibrationRecord.vue` was directly mutating pattern objects in place — bypassing Vuex reactivity entirely and leaving the app in a fragile, unpredictable state.

---

## Changes

| File | What changed |
|---|---|
| `src/store/predict.js` | Added `calibValidationResult` to state + `setCalibValidationResult` mutation |
| `src/store/calibration.js` | Added `setCalibrationPattern` mutation to properly set `runtime.usedPattern` |
| `src/views/DoubleCalibrationRecord.vue` | Commits `setCalibValidationResult` with prediction data after API response, so the result is available when `PostCalibration` mounts |

---
<img width="1919" height="1077" alt="Screenshot 2026-03-07 110045" src="https://github.com/user-attachments/assets/ee343eb3-d56e-491b-9d10-554976625848" />

## Why this matters

Without this fix, any future code that relies on `calibValidationResult` being populated would silently discard the adapted pattern and render `drawCalibPoints()` with no `predictionX`/`predictionY` — producing empty visualizations and NaN centroids. This PR closes that latent failure path and replaces the direct mutation workaround with a proper reactive store flow.