### PR TITLE
Fix text overlap in calibration name input field

### DIFF
--- a/src/components/calibration/GeneralConfigCard.vue
+++ b/src/components/calibration/GeneralConfigCard.vue
@@ -119,7 +119,7 @@ export default {
 .help-text {
     font-size: 12px;
     color: #666;
-    margin: -8px 0 8px 0;
+    margin: 12px 0 8px 0;
     font-style: italic;
 }
 </style>


### PR DESCRIPTION
- Adjusted help-text margin from -8px to 12px to prevent overlap with input box border
- Improves visual clarity and readability in General Configuration section
solves :#120  Text overlap in Calibration Name input field
screenshots:
<img width="897" height="328" alt="image" src="https://github.com/user-attachments/assets/2ca8785a-e1d3-4f7c-8a42-c80edf706943" />

