### PR TITLE
fix: search filter for mixed alphanumeric names

### DIFF
--- a/src/components/general/CalibTable.vue
+++ b/src/components/general/CalibTable.vue
@@ -48,9 +48,11 @@ export default {
       return this.$store.state.calibration.calibrations
     },
     filteredCalibrations() {
+      const searchTerm = this.search.toLowerCase();
+      if (!searchTerm) return this.calibrations;
       return this.calibrations.filter(calibration =>
         Object.values(calibration).some(value =>
-          value.toLowerCase().includes(this.search.toLowerCase())
+          String(value).toLowerCase().includes(searchTerm)
         )
       );
     },


### PR DESCRIPTION
Converts non-string values to strings before filtering so the search works with mixed letter-number calibration names.