### PR TITLE
fix: resolve text overlap in calibration name input help text

### DIFF
--- a/src/components/calibration/GeneralConfigCard.vue
+++ b/src/components/calibration/GeneralConfigCard.vue
@@ -119,7 +119,8 @@ export default {
 .help-text {
     font-size: 12px;
     color: #666;
-    margin: -8px 0 8px 0;
+    margin-top: 6px;
+    display: block;
     font-style: italic;
 }
 </style>


### PR DESCRIPTION
## Description

Fixes UI issue where help text in the "Calibration Name" input field overlaps with the input box border.

The issue was caused by a negative top margin in the `.help-text` class. Updated the margin to ensure proper spacing and improved readability.

## Related Issue

Closes #120

## Type of Change

- [x] Bug fix

## Testing

- [x] Manually verified (UI spacing logic)

## Checklist

- [x] Self-reviewed the code
- [x] No new warnings or errors introduced