### PR TITLE
feat(camera): gate calibration on webcam lighting quality check

### DIFF
--- a/src/views/CameraConfiguration.vue
+++ b/src/views/CameraConfiguration.vue
@@ -191,6 +191,12 @@
                       ></v-progress-circular>
                       <h4 class="mt-3">Loading face detection model...</h4>
                     </div>
+                    <div v-if="isCameraOn" class="d-flex justify-center mt-2">
+                      <v-chip small :color="lightingColor" dark>
+                        <v-icon left small>{{ lightingIcon }}</v-icon>
+                        {{ lighting.msg }}
+                      </v-chip>
+                    </div>
                   </v-card-text>
 
                   <v-card-actions class="justify-center py-2">
@@ -201,7 +207,7 @@
                     <v-btn
                       color="#FF425A"
                       dark
-                      :disabled="!isCameraOn"
+                      :disabled="!isCameraOn || !lightingReady"
                       @click="startCalibration"
                     >
                       <v-icon left>mdi-play</v-icon>
@@ -243,6 +249,9 @@ export default {
       showCameraModal: false,
       showFullscreenModal: false,
       fullscreenError: "",
+      lighting: { status: "unknown", msg: "Checking lighting..." },
+      lastLightCheck: 0,
+      goodLightStreak: 0,
     };
   },
   computed: {
@@ -266,6 +275,27 @@ export default {
     },
     rightEyeTreshold() {
       return this.$store.state.calibration.rightEyeTreshold;
+    },
+    lightingColor() {
+      return {
+        good: "green",
+        dark: "#455A64",
+        bright: "orange",
+        lowContrast: "amber darken-2",
+        unknown: "grey",
+      }[this.lighting.status];
+    },
+    lightingIcon() {
+      return {
+        good: "mdi-check-circle",
+        dark: "mdi-weather-night",
+        bright: "mdi-white-balance-sunny",
+        lowContrast: "mdi-contrast-circle",
+        unknown: "mdi-dots-horizontal",
+      }[this.lighting.status];
+    },
+    lightingReady() {
+      return this.goodLightStreak >= 3;
     },
   },
   watch: {
@@ -422,6 +452,17 @@ export default {
         canvas.height = this.video.videoHeight || 400;
         ctx.drawImage(this.video, 0, 0, canvas.width, canvas.height);
 
+        // Sample lighting at 2 Hz to keep the loop cheap.
+        const now = performance.now();
+        if (now - this.lastLightCheck > 500) {
+          this.lastLightCheck = now;
+          this.lighting = this.classifyLighting(
+            this.sampleLighting(ctx, canvas),
+          );
+          this.goodLightStreak =
+            this.lighting.status === "good" ? this.goodLightStreak + 1 : 0;
+        }
+
         const th = this;
 
         this.predictions.forEach((pred) => {
@@ -464,6 +505,33 @@ export default {
       if (this.isCameraOn) {
         requestAnimationFrame(() => this.detectFace());
       }
+    },
+    sampleLighting(ctx, canvas) {
+      // Mean and stddev of luminance over every 10th pixel.
+      const img = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+      let sum = 0;
+      let sumSq = 0;
+      let n = 0;
+      for (let i = 0; i < img.length; i += 40) {
+        const y = 0.299 * img[i] + 0.587 * img[i + 1] + 0.114 * img[i + 2];
+        sum += y;
+        sumSq += y * y;
+        n++;
+      }
+      const mean = sum / n;
+      const variance = sumSq / n - mean * mean;
+      return { mean, stddev: Math.sqrt(Math.max(0, variance)) };
+    },
+    classifyLighting({ mean, stddev }) {
+      if (mean < 60) return { status: "dark", msg: "Too dark - add more light" };
+      if (mean > 200)
+        return { status: "bright", msg: "Too bright - reduce backlight" };
+      if (stddev < 18)
+        return {
+          status: "lowContrast",
+          msg: "Low contrast - avoid flat lighting",
+        };
+      return { status: "good", msg: "Lighting OK" };
     },
     calculateDistance(eyelidTip, eyelidBottom) {
       const xDistance = eyelidBottom[0] - eyelidTip[0];


### PR DESCRIPTION
 ## Summary
  - Adds a real-time lighting quality indicator on the Camera Configuration
  screen.
  - Disables **Start Calibration** until the webcam feed has been in a
  "good" lighting state for ~1.5 s (3 consecutive samples at 2 Hz).
  - Helps users avoid calibrating under conditions that silently degrade
  gaze accuracy (too dark, backlit, or flat/low-contrast scenes).

  ## What changed
  `src/views/CameraConfiguration.vue`
  - Samples luminance (mean + stddev) from every 10th pixel of the existing
  `detectFace` RAF canvas at 2 Hz — no extra frame capture.
  - Classifies into `good` / `dark` / `bright` / `lowContrast` / `unknown`
  and renders a Vuetify chip under the preview with an icon + message.
  - `lightingReady` computed requires 3 consecutive `good` samples; the
  streak resets on any non-good reading, re-disabling the button.
  - `startCalibration` button `:disabled` now also checks `!lightingReady`.

  ## Classification thresholds 
  - `mean < 60` → dark
  - `mean > 200` → bright
  - `stddev < 18` → low contrast
  - otherwise → good
  ## Testing 
  - unstable photo : 
  
<img width="984" height="617" alt="Screenshot 2026-04-23 223420" src="https://github.com/user-attachments/assets/1342f27f-b4b5-4763-bfa3-eac6778ef155" />

 - stable one: 
 
<img width="556" height="132" alt="Screenshot 2026-04-23 223437" src="https://github.com/user-attachments/assets/43600c4a-b997-4c0b-848d-a594203a8644" />

 ## References :
  - luminance coefficients: https://en.wikipedia.org/wiki/Rec._601
  -  MDN `getImageData`: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData
 
 